### PR TITLE
force init of StackTraceHelper prop via reflection

### DIFF
--- a/BugRepro1/UnitTest1.cs
+++ b/BugRepro1/UnitTest1.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace BugRepro1
@@ -7,6 +8,23 @@ namespace BugRepro1
     [TestClass]
     public class UnitTest1
     {
+        [AssemblyInitialize]
+        public static void ForceStackTraceHelperInitialization(TestContext context)
+        {
+            Type? stackTraceHelperType = null;
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var tryGetType = assembly.GetType("Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.StackTraceHelper");
+                if (tryGetType != null)
+                {
+                    stackTraceHelperType = tryGetType;
+                    break;
+                }
+            }
+            PropertyInfo? propertyInfo = stackTraceHelperType.GetProperty("TypeToBeExcluded", BindingFlags.NonPublic | BindingFlags.Static);
+            Console.WriteLine($"{propertyInfo.GetValue(null)}");
+        }
+
         [TestMethod]
         public async Task AlwaysSkip()
         {


### PR DESCRIPTION
With this change I can no longer reproduce https://github.com/microsoft/testfx/issues/1053, presumably because it forces https://github.com/microsoft/testfx/blob/rel/2.2.8/src/Adapter/MSTest.CoreAdapter/Execution/StackTraceHelper.cs#L35 to run before tests start running in parallell.